### PR TITLE
Fix bug with file name instead of full path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skippy-cov"
-version = "0.1.4"
+version = "0.1.5"
 description = "Selectively run tests based on the current git diff and the collected data from previous tests runs"
 authors = [
     { name = "Mariano Garcia Berrotaran", email = "mariano.garciaberrotaran@shiphero.com" },

--- a/skippy_cov/utils.py
+++ b/skippy_cov/utils.py
@@ -117,7 +117,7 @@ class CoverageMap:
 
     def get_tests(self, filepath: Path) -> FileTestCandidate | None:
         tests = set()
-        for line_tests in self.db.contexts_by_lineno(filepath.name).values():
+        for line_tests in self.db.contexts_by_lineno(filepath.as_posix()).values():
             tests |= {_fix_test_name(test) for test in line_tests}
         if tests:
             return FileTestCandidate(path=filepath, tests=tests)

--- a/uv.lock
+++ b/uv.lock
@@ -667,7 +667,7 @@ wheels = [
 
 [[package]]
 name = "skippy-cov"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
Some tests were not reachable because we were using the `.name` property instead of `.as_posix()` for the file path.