### PR TITLE
Rename --coverage-map-file option to --coverage-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can provide the diff to `skippy-cov` in two ways:
   You can specify a branch or ref to diff against (e.g., the main branch):
 
   ```bash
-      skippy-cov --diff main --coverage-map-file .coverage
+      skippy-cov --diff main --coverage-file .coverage
   ```
 
 * **Option 2: Use a Diff File**
@@ -34,28 +34,33 @@ You can provide the diff to `skippy-cov` in two ways:
 
   Then run:
 
-But it can also be used as `pytest` plugin:
   ```bash
-      skippy-cov --diff changes.diff --coverage-map-file .coverage
+      skippy-cov --diff changes.diff --coverage-file .coverage
   ```
 
-
-If you omit the `--diff` argument, it will default to the main branch as determined by your git remote (usually "main" or "master"):
+* **Option 1: Use a Git Branch or Ref**  
+  You can specify a branch or ref to diff against (e.g., the main branch):
 
   ```bash
-      skippy-cov --coverage-map-file .coverage
+      skippy-cov --diff main --coverage-file .coverage
+  ```
+
+  If you omit the `--diff` argument, it will default to the main branch as determined by your git remote (usually "main" or "master"):
+
+  ```bash
+      skippy-cov --coverage-file .coverage
   ```
 
 But it can also be used as a `pytest` plugin:
 
 ```bash
-    pytest --skippy-cov --skippy-cov-diff changes.diff --skippy-cov-coverage-map-file .coverage
+    pytest --skippy-cov --skippy-cov-diff changes.diff --skippy-cov-coverage-file .coverage
 ```
 
 which would be the equivalent of doing this:
 
 ```bash
-    pytest $(skippy-cov --diff changes.diff --coverage-map-file .coverage)
+    pytest $(skippy-cov --diff changes.diff --coverage-file .coverage)
 ```
 
 ## Configuration
@@ -70,13 +75,9 @@ which would be the equivalent of doing this:
   - If omitted, defaults to the main branch as determined by `git remote show origin`.
 
 Example usages:
-- `skippy-cov --diff changes.diff --coverage-map-file .coverage`
-- `skippy-cov --diff main --coverage-map-file .coverage`
-- `skippy-cov --coverage-map-file .coverage` (defaults to main branch)
-
-#### System Requirements
-
-For the diff argument to work, this requires a working `git` installation.
+- `skippy-cov --diff changes.diff --coverage-file .coverage`
+- `skippy-cov --diff main --coverage-file .coverage`
+- `skippy-cov --coverage-file .coverage` (defaults to main branch)
 
 ## Contributing
 

--- a/skippy_cov/__main__.py
+++ b/skippy_cov/__main__.py
@@ -107,9 +107,9 @@ def main(argv=None):
         default=None,
     )
     parser.add_argument(
-        "--coverage-map-file",
+        "--coverage-file",
         required=False,
-        help="Path to the coverage map file (.coverage sqlite database).",
+        help="Path to the coverage file (.coverage sqlite database).",
         type=Path,
         default=Path(".coverage"),
     )
@@ -148,7 +148,7 @@ def main(argv=None):
 
     run(
         diff_content,
-        args.coverage_map_file,
+        args.coverage_file,
         args.relative_to,
         args.keep_prefix,
         display=True,

--- a/skippy_cov/plugin.py
+++ b/skippy_cov/plugin.py
@@ -26,9 +26,9 @@ def pytest_addoption(parser):
         default=None,
     )
     group.addoption(
-        "--skippy-cov-coverage-map-file",
+        "--skippy-cov-coverage-file",
         required=False,
-        help="Path to the coverage map file (.coverage sqlite database).",
+        help="Path to the coverage file (.coverage sqlite database).",
         type=Path,
         default=Path(".coverage"),
     )
@@ -55,7 +55,7 @@ def pytest_configure(config):
     """
     skippy_cov = config.getoption("skippy_cov")
     diff_arg = config.getoption("skippy_cov_diff")
-    cov_map_file = config.getoption("skippy_cov_coverage_map_file")
+    cov_file = config.getoption("skippy_cov_coverage_file")
     keep_prefix = config.getoption("skippy_cov_keep_prefix")
     if not skippy_cov:
         return
@@ -70,7 +70,7 @@ def pytest_configure(config):
     relative_to = [Path(x) for x in config.args if x]
     selected_tests = run(
         diff_content,
-        cov_map_file,
+        cov_file,
         relative_to,
         keep_prefix,
     )

--- a/tests/test_cli_diff.py
+++ b/tests/test_cli_diff.py
@@ -35,7 +35,7 @@ def test_diff_file_mode(dummy_diff_file, dummy_coverage_file, capsys):
     argv = [
         "--diff",
         str(diff_file),
-        "--coverage-map-file",
+        "--coverage-file",
         str(cov_file.resolve()),
     ]
     try:
@@ -66,7 +66,7 @@ def test_diff_git_branch_mode(tmp_path, dummy_coverage_file, capsys):
     argv = [
         "--diff",
         "main",
-        "--coverage-map-file",
+        "--coverage-file",
         str(cov_file.resolve()),
     ]
     old_cwd = os.getcwd()
@@ -98,7 +98,7 @@ def test_diff_default_branch(tmp_path, dummy_coverage_file, capsys):
     subprocess.run(["git", "commit", "-m", "change"], cwd=repo, check=True)
     cov_file = dummy_coverage_file
     argv = [
-        "--coverage-map-file",
+        "--coverage-file",
         str(cov_file.resolve()),
     ]
     old_cwd = os.getcwd()


### PR DESCRIPTION
Renamed all instances of the CLI/pytest argument `--coverage-map-file` to `--coverage-file` across the codebase, documentation, and tests.

IMHO improves clarity and consistency by using a simpler, more intuitive argument name for specifying the coverage data file.
