### PR TITLE
[Context] Extract the test path from the coverage response.

### DIFF
--- a/skippy_cov/__init__.py
+++ b/skippy_cov/__init__.py
@@ -85,12 +85,13 @@ def select_tests_to_run(
 
     for file_path in diff_handler.changed_files:
         # 1. If the changed file is a source file with known coverage
-        if candidate := coverage_map.get_tests(file_path):
-            logger.debug(
-                f"Source file '{candidate.path}' changed. Adding {len(candidate.tests)}"
-                "related test(s) from coverage map.",
-            )
-            tests_to_run.append(candidate)
+        if candidates := coverage_map.get_tests(file_path):
+            for candidate in candidates:
+                logger.debug(
+                    f"Source file '{candidate.path}' changed. Adding {len(candidate.tests)}"
+                    " related test(s) from coverage map.",
+                )
+                tests_to_run.append(candidate)
 
         # 2. If the changed file is a test file itself
         # Use the discovery function, which internally checks if it's a test file

--- a/tests/test_coverage_map.py
+++ b/tests/test_coverage_map.py
@@ -14,7 +14,7 @@ def mocked_coverage(mocker: MockerFixture) -> MagicMock:
     mock = mocker.patch("skippy_cov.utils.coverage.CoverageData")
     coverage_db: MagicMock = mock.return_value
     coverage_db.read.return_value = True
-    coverage_db._file_map.keys.return_value = ["test.py"]
+    coverage_db._file_map.keys.return_value = ["source.py"]
     coverage_db.contexts_by_lineno.return_value = {
         1: ["test.py::test1|run", "test.py::test2|run"],
     }
@@ -23,13 +23,15 @@ def mocked_coverage(mocker: MockerFixture) -> MagicMock:
 
 def test_load_coverage_map(mocked_coverage: MagicMock) -> None:
     coverage_map = CoverageMap(Path("coverage.db"))
-    assert coverage_map.get_tests(Path("test.py")) == FileTestCandidate(
-        path=Path("test.py"),
-        tests={
-            "test.py::test1",
-            "test.py::test2",
-        },
-    )
+    assert coverage_map.get_tests(Path("source.py")) == [
+        FileTestCandidate(
+            path=Path("test.py"),
+            tests={
+                "test1",
+                "test2",
+            },
+        )
+    ]
 
 
 def test_load_coverage_map_nested_folder(mocked_coverage: MagicMock) -> None:
@@ -37,6 +39,6 @@ def test_load_coverage_map_nested_folder(mocked_coverage: MagicMock) -> None:
     Ensure the path is correctly parsed to the coverage db
     """
     coverage_map = CoverageMap(Path("coverage.db"))
-    candidate = coverage_map.get_tests(Path("tests/test.py"))
-    mocked_coverage.contexts_by_lineno.assert_called_with("tests/test.py")
-    assert candidate and candidate.path == Path("tests/test.py")
+    candidates = coverage_map.get_tests(Path("src/source.py"))
+    mocked_coverage.contexts_by_lineno.assert_called_with("src/source.py")
+    assert candidates and candidates[0].path == Path("test.py")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,19 +31,19 @@ def test_config_is_test_file(mocker: MockFixture) -> None:
 @pytest.mark.parametrize(
     "name,expected",
     [
-        ("test_file.py::test_name", "test_file.py::test_name"),
-        ("test_file.py::ClassName::test_name", "test_file.py::ClassName::test_name"),
+        ("test_file.py::test_name", ("test_file.py", "test_name")),
+        ("test_file.py::ClassName::test_name", ("test_file.py", "ClassName::test_name")),
         (
             "test_file.py::test_name[param1, param2]",
-            "test_file.py::test_name[param1, param2]",
+            ("test_file.py", "test_name[param1, param2]"),
         ),
         (
             "test_file.py::test_name[param1, param2]|phase",
-            "test_file.py::test_name[param1, param2]",
+            ("test_file.py", "test_name[param1, param2]"),
         ),
         (
             "test_file.py::test_name[param|param]|phase",
-            "test_file.py::test_name[param|param]",
+            ("test_file.py", "test_name[param|param]"),
         ),
     ],
 )


### PR DESCRIPTION
We were wrongfuly assuming the path of the test was the original file, so if `my_feature.py` was related to `test.py::test1` and `test2.py::other_test`, we were masshing both together as `my_feature.py::test.py::test1 my_feature.py::test2.py::other_test`.

With this PR, we not only fix that, but also cover the case where a single surce file covers different test files.
